### PR TITLE
Add hasMessageSatisfying method to MessagesAssert

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ void shouldFilterMessages() {
         .allMessagesSatisfy(msg -> msg
             .isFrom("noreply@company.com")
             .hasNoAttachments());
+
+    // Assert on specific messages by index
+    assertThat(mailpit)
+        .messages()
+        .hasMessageSatisfying(0, msg -> msg.hasSubject("Welcome").isUnread())
+        .hasMessageSatisfying(1, msg -> msg.hasSubject("Confirmation").hasRecipient("user@example.com"))
+        .hasMessageSatisfying(2, msg -> msg.hasSubject("Newsletter"));
 }
 ```
 

--- a/src/main/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MessagesAssert.java
+++ b/src/main/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MessagesAssert.java
@@ -188,6 +188,9 @@ public class MessagesAssert extends AbstractIterableAssert<MessagesAssert, List<
 	 */
 	public MessagesAssert hasMessageSatisfying(int index, Consumer<MessageAssert> assertion) {
 		isNotNull();
+		if (index < 0) {
+			failWithMessage("Index must be non-negative but was: %d", index);
+		}
 		Assertions.assertThat(actual).hasSizeGreaterThan(index);
 		assertion.accept(new MessageAssert(actual.get(index)));
 		return this;

--- a/src/main/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MessagesAssert.java
+++ b/src/main/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MessagesAssert.java
@@ -180,6 +180,20 @@ public class MessagesAssert extends AbstractIterableAssert<MessagesAssert, List<
 	}
 
 	/**
+	 * Applies MessageAssert assertions on a message at the specified index.
+	 * @param index the index of the message
+	 * @param assertion the assertion to apply
+	 * @return this assertion object
+	 * @throws AssertionError if the index is out of bounds
+	 */
+	public MessagesAssert hasMessageSatisfying(int index, Consumer<MessageAssert> assertion) {
+		isNotNull();
+		Assertions.assertThat(actual).hasSizeGreaterThan(index);
+		assertion.accept(new MessageAssert(actual.get(index)));
+		return this;
+	}
+
+	/**
 	 * Verifies that all messages are from the given sender.
 	 * @param senderAddress the expected sender email address
 	 * @return this assertion object

--- a/src/test/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MailpitAssertionsTest.java
+++ b/src/test/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MailpitAssertionsTest.java
@@ -323,6 +323,27 @@ class MailpitAssertionsTest {
 			assertThat(mailpit).messages().allMessagesSatisfy(msg -> msg.isFrom("sender@test.com").isUnread());
 		}
 
+		@Test
+		void shouldHasMessageSatisfying() throws MessagingException {
+			sendEmail("sender@test.com", "recipient@test.com", "Email 1", "Body 1");
+			sendEmail("sender@test.com", "recipient@test.com", "Email 2", "Body 2");
+			sendEmail("sender@test.com", "recipient@test.com", "Email 3", "Body 3");
+
+			assertThat(mailpit).messages()
+				.hasMessageSatisfying(0, msg -> msg.hasSubject("Email 3").isFrom("sender@test.com").isUnread())
+				.hasMessageSatisfying(1, msg -> msg.hasSubject("Email 2").hasRecipient("recipient@test.com"))
+				.hasMessageSatisfying(2, msg -> msg.hasSubject("Email 1"));
+		}
+
+		@Test
+		void shouldFailWhenIndexOutOfBounds() throws MessagingException {
+			sendEmail("sender@test.com", "recipient@test.com", "Email 1", "Body");
+
+			assertThatThrownBy(() -> assertThat(mailpit).messages()
+				.hasMessageSatisfying(5, msg -> msg.hasSubject("Email 1")))
+				.isInstanceOf(AssertionError.class);
+		}
+
 	}
 
 	@Nested

--- a/src/test/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MailpitAssertionsTest.java
+++ b/src/test/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MailpitAssertionsTest.java
@@ -344,6 +344,16 @@ class MailpitAssertionsTest {
 				.isInstanceOf(AssertionError.class);
 		}
 
+		@Test
+		void shouldFailWhenIndexIsNegative() throws MessagingException {
+			sendEmail("sender@test.com", "recipient@test.com", "Email 1", "Body");
+
+			assertThatThrownBy(
+					() -> assertThat(mailpit).messages().hasMessageSatisfying(-1, msg -> msg.hasSubject("Email 1")))
+				.isInstanceOf(AssertionError.class)
+				.hasMessageContaining("Index must be non-negative but was: -1");
+		}
+
 	}
 
 	@Nested

--- a/src/test/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MailpitAssertionsTest.java
+++ b/src/test/java/ch/martinelli/oss/testcontainers/mailpit/assertions/MailpitAssertionsTest.java
@@ -339,8 +339,8 @@ class MailpitAssertionsTest {
 		void shouldFailWhenIndexOutOfBounds() throws MessagingException {
 			sendEmail("sender@test.com", "recipient@test.com", "Email 1", "Body");
 
-			assertThatThrownBy(() -> assertThat(mailpit).messages()
-				.hasMessageSatisfying(5, msg -> msg.hasSubject("Email 1")))
+			assertThatThrownBy(
+					() -> assertThat(mailpit).messages().hasMessageSatisfying(5, msg -> msg.hasSubject("Email 1")))
 				.isInstanceOf(AssertionError.class);
 		}
 


### PR DESCRIPTION
## Summary
- Adds `hasMessageSatisfying(int index, Consumer<MessageAssert> assertion)` method to `MessagesAssert`
- Allows fluent assertion on specific messages by index in a collection
- Includes comprehensive tests for the new method
- Documents the new method in README with usage examples

## Test plan
- [x] Added unit tests for `hasMessageSatisfying` including error handling
- [x] All existing tests pass
- [x] Documentation updated with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)